### PR TITLE
Install n510-tx2 dtb only for this machine

### DIFF
--- a/layers/meta-resin-jetson/recipes-kernel/linux/linux-tegra_%.bbappend
+++ b/layers/meta-resin-jetson/recipes-kernel/linux/linux-tegra_%.bbappend
@@ -76,7 +76,10 @@ do_deploy_append() {
     install -m 0600 "${D}/boot/extlinux/extlinux.conf_flasher" "${DEPLOYDIR}"
 
     cp ${WORKDIR}/tegra186-tx2-cti-ASG001-USB3.dtb "${DEPLOYDIR}"
-    cp ${WORKDIR}/tegra186-quill-p3310-1000-c03-00-base.dtb "${DEPLOYDIR}"
     cp ${WORKDIR}/tegra186-tx2-cti-ASG006-IMX274-6CAM.dtb "${DEPLOYDIR}"
     cp ${WORKDIR}/tegra186-tx2-cti-ASG916.dtb "${DEPLOYDIR}"
+}
+
+do_deploy_append_n510-tx2() {
+    cp ${WORKDIR}/tegra186-quill-p3310-1000-c03-00-base.dtb "${DEPLOYDIR}"
 }


### PR DESCRIPTION
The device tree for the n510-tx2 machine seems to be loaded
by the first stage bootloader program(before u-boot) on the
jetson-tx2 instead of the jetson-tx2 device tree.
This patch installs the n510-tx2 device tree only when the machine
is built.

Changelog-entry: Install n510-tx2 dtb only for this machine
Signed-off-by: Sebastian Panceac <sebastian@balena.io>